### PR TITLE
chroe: update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.19
+          go-version: ^1.22
       - run: go mod download
       - run: make -j all
       - run: make -j test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.19
+          go-version: ^1.22
       - run: go mod download
       - run: make -j upload
         env:

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/c3b2a7/sshtunnel
 
 go 1.22
 
-require golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+require golang.org/x/crypto v0.24.0
+
+require golang.org/x/sys v0.21.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/c3b2a7/sshtunnel
 
-go 1.19
+go 1.22
 
 require golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.24.0 h1:mnl8DM0o513X8fdIkmyFE/5hTYxbwYOjDS/+rK6qpRI=
+golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5DM=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.21.0 h1:WVXCp+/EBEHOj53Rvu+7KiT/iElMrO8ACK16SMZ3jaA=
+golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=


### PR DESCRIPTION
- chore: use go v1.22
- chore: update golang.org/x/crypto to v0.24.0