### PR TITLE
fix: allow release asset uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     types: [ published ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- grant the release workflow contents: write so GITHUB_TOKEN can upload release assets
