### PR TITLE
fix: improve tunnel log messages

### DIFF
--- a/internal/socks/socks.go
+++ b/internal/socks/socks.go
@@ -28,7 +28,35 @@ const (
 type Error byte
 
 func (err Error) Error() string {
-	return "SOCKS error: " + strconv.Itoa(int(err))
+	if name := err.String(); name != "" {
+		return name + " (" + strconv.Itoa(int(err)) + ")"
+	}
+	return "error: " + strconv.Itoa(int(err))
+}
+
+func (err Error) String() string {
+	switch err {
+	case ErrGeneralFailure:
+		return "general failure"
+	case ErrConnectionNotAllowed:
+		return "connection not allowed"
+	case ErrNetworkUnreachable:
+		return "network unreachable"
+	case ErrHostUnreachable:
+		return "host unreachable"
+	case ErrConnectionRefused:
+		return "connection refused"
+	case ErrTTLExpired:
+		return "TTL expired"
+	case ErrCommandNotSupported:
+		return "command not supported"
+	case ErrAddressNotSupported:
+		return "address type not supported"
+	case InfoUDPAssociate:
+		return "UDP associate"
+	default:
+		return ""
+	}
 }
 
 // SOCKS errors as defined in RFC 1928 section 6.

--- a/internal/socks/socks_test.go
+++ b/internal/socks/socks_test.go
@@ -36,6 +36,25 @@ func TestParseAddrStringRoundTrip(t *testing.T) {
 	}
 }
 
+func TestErrorString(t *testing.T) {
+	tests := []struct {
+		err  Error
+		want string
+	}{
+		{err: ErrAddressNotSupported, want: "address type not supported (8)"},
+		{err: ErrCommandNotSupported, want: "command not supported (7)"},
+		{err: Error(99), want: "error: 99"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Fatalf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseAddrRejectsInvalidInput(t *testing.T) {
 	tests := []string{
 		"example.com",

--- a/tunnel.go
+++ b/tunnel.go
@@ -177,20 +177,24 @@ func handleTunnelConn(ctx context.Context, client *ssh.Client, tunnel TunnelSpec
 		if errors.Is(err, ErrSkipRelay) {
 			return
 		}
-		log.Errorf(ctx, "failed to connect to %s via server %s: %v", targetAddr, client.RemoteAddr(), err)
+		if targetAddr == "" {
+			log.Errorf(ctx, "failed to connect target: %v", err)
+		} else {
+			log.Errorf(ctx, "failed to connect target %s: %v", targetAddr, err)
+		}
 		return
 	}
 	if targetConn == nil {
-		log.Errorf(ctx, "failed to connect to %s via server %s: empty connection", targetAddr, client.RemoteAddr())
+		log.Errorf(ctx, "failed to connect target %s: empty target connection", targetAddr)
 		return
 	}
 	defer targetConn.Close()
 
 	log.Debugf(
-		ctx, "tunneling(%s) %s -> %s <-> %s -> %s",
+		ctx, "tunneling(%s) client %s -> client target %s <-> ssh server %s -> target %s",
 		tunnel.Mode,
-		client.LocalAddr(), client.RemoteAddr(),
-		targetConn.LocalAddr(), targetConn.RemoteAddr(),
+		clientConn.RemoteAddr(), clientConn.LocalAddr(),
+		client.RemoteAddr(), targetAddr,
 	)
 	if err = relay(ctx, targetConn, clientConn); err != nil {
 		log.Errorf(ctx, "relay error: %v", err)
@@ -230,7 +234,7 @@ func openDynamicTarget(ctx context.Context, client *ssh.Client, tunnel TunnelSpe
 		return nil, "", ErrSkipRelay
 	}
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("socks handshake: %w", err)
 	}
 
 	conn, err := client.DialContext(ctx, "tcp", targetAddr.String())


### PR DESCRIPTION
## Summary
- Add readable SOCKS error names so tunnel logs include useful failure context.
- Clarify dynamic SOCKS handshake failures and tunnel connection debug output.

## Impact
- Operators get clearer failure messages without changing tunnel behavior.

## Validation
- `GOCACHE=/private/tmp/sshtunnel-go-cache go test ./...`
