### PR TITLE
feat: support ssh agent authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ runs one or more tunnels from a JSON config file.
 
 - Local, remote, and dynamic SSH forwarding.
 - Multiple tunnels over one SSH connection.
-- Private key, encrypted private key, and password authentication.
+- Private key, SSH agent socket, and password authentication.
 - JSON configuration for repeatable tunnel setups.
 
 ## Installation
@@ -48,7 +48,7 @@ Create a config file:
   "target": "ssh.example.com:22",
   "username": "alice",
   "private-key": "/home/alice/.ssh/id_ed25519",
-  "passphrase": "private key passphrase or account password",
+  "passphrase": "private key passphrase",
   "tunnels": [
     {
       "mode": "local",
@@ -107,31 +107,42 @@ Usage of sshtunnel:
 
 ## Configuration
 
-Top-level fields:
+**Top-level fields:**
 
-| Field | Required | Description |
-| --- | --- | --- |
-| `target` | Yes | SSH server address, in `host:port` format. |
-| `username` | Yes | SSH username. |
-| `private-key` | No | Path to an SSH private key. Leave empty for password auth. |
-| `passphrase` | No | Private key passphrase, or SSH password when `private-key` is empty. |
-| `tunnels` | Yes | List of tunnel definitions. |
+| Field           | Required | Description                                                                                                                                                         |
+|-----------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `target`        | Yes      | SSH server address, in `host:port` format.                                                                                                                          |
+| `username`      | Yes      | SSH username.                                                                                                                                                       |
+| `private-key`   | No       | Path to an SSH private key. When set, it is tried first as a public key authentication source.                                                                      |
+| `ssh_auth_sock` | No       | Unix socket path for SSH agent authentication. Agent identities are tried after `private-key`; if unset, the fallback is `SSH_AUTH_SOCK` read from the environment. |
+| `passphrase`    | No       | Private key passphrase when `private-key` is set; otherwise the SSH password, tried after public key authentication.                                                |
+| `tunnels`       | Yes      | List of tunnel definitions.                                                                                                                                         |
 
-Tunnel fields:
+**Tunnel definitions:**
 
-| Field | Required | Description |
-| --- | --- | --- |
-| `mode` | Yes | One of `local`, `remote`, or `dynamic`. |
-| `local` | Yes | Local listen address for `local` and `dynamic`; local target service for `remote`. |
+| Field    | Required                 | Description                                                                                      |
+|----------|--------------------------|--------------------------------------------------------------------------------------------------|
+| `mode`   | Yes                      | One of `local`, `remote`, or `dynamic`.                                                          |
+| `local`  | Yes                      | Local listen address for `local` and `dynamic`; local target service for `remote`.               |
 | `remote` | For `local` and `remote` | Remote target service for `local`; SSH server listen address for `remote`. Ignored by `dynamic`. |
+
+## Authentication order:
+
+`private-key` public key auth -> `ssh_auth_sock` agent auth -> `SSH_AUTH_SOCK` (from environment variable) agent auth ->
+`passphrase` password auth
+
+`passphrase` has two meanings:
+
+- When `private-key` is set, `passphrase` is the private key passphrase.
+- When `private-key` is not set, `passphrase` is used as the SSH password after public key authentication.
 
 ## Forwarding Modes
 
-| Mode | Use case |
-| --- | --- |
-| `local` | Reach a remote service from your machine. |
-| `remote` | Expose a local service on the SSH server side. |
-| `dynamic` | Use the SSH server as a SOCKS5 proxy. |
+| Mode      | Use case                                       |
+|-----------|------------------------------------------------|
+| `local`   | Reach a remote service from your machine.      |
+| `remote`  | Expose a local service on the SSH server side. |
+| `dynamic` | Use the SSH server as a SOCKS5 proxy.          |
 
 Traffic flow diagrams are hidden by default. Expand them when you need the
 connection path for a specific mode.

--- a/config.go
+++ b/config.go
@@ -15,11 +15,12 @@ type AppConfig struct {
 var ErrNoTunnels = errors.New("at least one tunnel is required")
 
 type fileConfig struct {
-	Target     string         `json:"target"`
-	Username   string         `json:"username"`
-	PrivateKey string         `json:"private-key"`
-	Passphrase string         `json:"passphrase"`
-	Tunnels    []tunnelConfig `json:"tunnels,omitempty"`
+	Target      string         `json:"target"`
+	Username    string         `json:"username"`
+	PrivateKey  string         `json:"private-key"`
+	Passphrase  string         `json:"passphrase"`
+	SSHAuthSock string         `json:"ssh_auth_sock"`
+	Tunnels     []tunnelConfig `json:"tunnels,omitempty"`
 }
 
 type tunnelConfig struct {
@@ -50,9 +51,10 @@ func (c fileConfig) toAppConfig() (AppConfig, error) {
 
 	config := AppConfig{
 		SSH: SSHConfig{
-			Server:     server,
-			Username:   c.Username,
-			Passphrase: c.Passphrase,
+			Server:      server,
+			Username:    c.Username,
+			Passphrase:  c.Passphrase,
+			SSHAuthSock: c.SSHAuthSock,
 		},
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,22 +10,18 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.json")
-	body := `{
-		"target": "ssh.example.com:22",
-		"username": "alice",
-		"passphrase": "secret",
-		"tunnels": [
-			{"local": "127.0.0.1:13306", "remote": "10.0.0.2:3306", "mode": "local"},
-			{"local": "127.0.0.1:1080", "mode": "dynamic"}
-		]
-	}`
+	cfgPath := filepath.Join(dir, "config.json")
+	writeConfigFile(t, cfgPath, fileConfig{
+		Target:     "ssh.example.com:22",
+		Username:   "alice",
+		Passphrase: "secret",
+		Tunnels: []tunnelConfig{
+			{Local: "127.0.0.1:13306", Remote: "10.0.0.2:3306", Mode: "local"},
+			{Local: "127.0.0.1:1080", Mode: "dynamic"},
+		},
+	})
 
-	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	config, err := LoadConfig(configPath)
+	config, err := LoadConfig(cfgPath)
 	if err != nil {
 		t.Fatalf("LoadConfig() error = %v", err)
 	}
@@ -32,6 +30,9 @@ func TestLoadConfig(t *testing.T) {
 	}
 	if config.SSH.Username != "alice" {
 		t.Fatalf("SSH username = %q, want %q", config.SSH.Username, "alice")
+	}
+	if config.SSH.Passphrase != "secret" {
+		t.Fatalf("SSH passphrase = %q, want %q", config.SSH.Passphrase, "secret")
 	}
 	if len(config.Tunnels) != 2 {
 		t.Fatalf("tunnel count = %d, want 2", len(config.Tunnels))
@@ -46,57 +47,89 @@ func TestLoadConfig(t *testing.T) {
 
 func TestLoadConfigRejectsInvalidTunnel(t *testing.T) {
 	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.json")
-	body := `{
-		"target": "ssh.example.com:22",
-		"username": "alice",
-		"tunnels": [
-			{"local": "127.0.0.1:1080", "mode": "invalid"}
-		]
-	}`
+	cfgPath := filepath.Join(dir, "config.json")
+	writeConfigFile(t, cfgPath, fileConfig{
+		Target:   "ssh.example.com:22",
+		Username: "alice",
+		Tunnels: []tunnelConfig{
+			{Local: "127.0.0.1:1080", Mode: "invalid"},
+		},
+	})
 
-	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := LoadConfig(configPath); err == nil {
+	if _, err := LoadConfig(cfgPath); err == nil {
 		t.Fatal("LoadConfig() error = nil, want error")
 	}
 }
 
 func TestLoadConfigRejectsLocalTunnelWithoutRemote(t *testing.T) {
 	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.json")
-	body := `{
-		"target": "ssh.example.com:22",
-		"username": "alice",
-		"tunnels": [
-			{"local": "127.0.0.1:13306", "mode": "local"}
-		]
-	}`
+	cfgPath := filepath.Join(dir, "config.json")
+	writeConfigFile(t, cfgPath, fileConfig{
+		Target:   "ssh.example.com:22",
+		Username: "alice",
+		Tunnels: []tunnelConfig{
+			{Local: "127.0.0.1:13306", Mode: "local"},
+		},
+	})
 
-	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := LoadConfig(configPath); err == nil {
+	if _, err := LoadConfig(cfgPath); err == nil {
 		t.Fatal("LoadConfig() error = nil, want error")
 	}
 }
 
 func TestLoadConfigRejectsEmptyTunnelList(t *testing.T) {
 	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.json")
-	body := `{
-		"target": "ssh.example.com:22",
-		"username": "alice"
-	}`
+	cfgPath := filepath.Join(dir, "config.json")
+	writeConfigFile(t, cfgPath, fileConfig{
+		Target:   "ssh.example.com:22",
+		Username: "alice",
+	})
 
-	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
+	if _, err := LoadConfig(cfgPath); err == nil {
+		t.Fatal("LoadConfig() error = nil, want error")
+	}
+}
+
+func TestLoadConfigSSHAuthSock(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	keyPath := filepath.Join(dir, "id_ed25519")
+	agentSockPath := filepath.Join(dir, "agent.sock")
+
+	key := []byte("test-key")
+	if err := os.WriteFile(keyPath, key, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	writeConfigFile(t, cfgPath, fileConfig{
+		Target:      "ssh.example.com:22",
+		Username:    "alice",
+		PrivateKey:  keyPath,
+		SSHAuthSock: agentSockPath,
+		Tunnels: []tunnelConfig{
+			{Local: "127.0.0.1:1080", Mode: "dynamic"},
+		},
+	})
 
-	if _, err := LoadConfig(configPath); err == nil {
-		t.Fatal("LoadConfig() error = nil, want error")
+	config, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if config.SSH.SSHAuthSock != agentSockPath {
+		t.Fatalf("SSH auth sock = %q, want %q", config.SSH.SSHAuthSock, agentSockPath)
+	}
+	if !bytes.Equal(config.SSH.PrivateKey, key) {
+		t.Fatalf("SSH private key = %q, want %q", string(config.SSH.PrivateKey), string(key))
+	}
+}
+
+func writeConfigFile(t *testing.T, path string, config fileConfig) {
+	t.Helper()
+
+	body, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	client, err := DialSSH(config.SSH)
+	client, err := DialSSH(ctx, config.SSH)
 	if err != nil {
 		return err
 	}
@@ -59,13 +59,12 @@ func run(ctx context.Context) error {
 	for i, tunnel := range config.Tunnels {
 		tunnelID := fmt.Sprintf("tunnel-%d", i+1)
 		tunnelCtx := log.WithTunnelLogger(ctx, tunnelID)
-
-		log.Infof(tunnelCtx, "starting %s: mode=%s localAddr=%s remoteAddr=%s", tunnelID, tunnel.Mode, tunnel.Local, tunnel.Remote)
+		log.Infof(tunnelCtx, "starting: mode=%s local=%s remote=%s", tunnel.Mode, tunnel.Local, tunnel.Remote)
 		if err = ServeTunnel(tunnelCtx, client, tunnel); err != nil {
 			return fmt.Errorf("failed to start %s: %v", tunnelID, err)
 		}
-		log.Infof(tunnelCtx, "started %s", tunnelID)
 	}
+	log.Infof(ctx, "all tunnel started")
 
 	<-ctx.Done()
 	log.Infof(ctx, "exiting")

--- a/ssh.go
+++ b/ssh.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type SSHConfig struct {
+	Server      NetworkAddress
+	Username    string
+	PrivateKey  []byte
+	Passphrase  string
+	SSHAuthSock string
+}
+
+type authMethodKind string
+
+const (
+	authMethodPrivateKey authMethodKind = "private-key"
+	authMethodSSHAgent   authMethodKind = "ssh-agent"
+	authMethodPassword   authMethodKind = "password"
+)
+
+type authMethodSpec struct {
+	kind   authMethodKind
+	method ssh.AuthMethod
+	closer io.Closer
+}
+
+type authMethods struct {
+	specs []authMethodSpec
+}
+
+func (auth *authMethods) methods() []ssh.AuthMethod {
+	methods := make([]ssh.AuthMethod, 0, len(auth.specs))
+	for _, spec := range auth.specs {
+		methods = append(methods, spec.method)
+	}
+	return methods
+}
+
+func (auth *authMethods) close() error {
+	var firstErr error
+	for _, spec := range auth.specs {
+		if spec.closer == nil {
+			continue
+		}
+		if err := spec.closer.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// DialSSH opens an SSH client connection using the configured authentication methods.
+func DialSSH(ctx context.Context, config SSHConfig) (*ssh.Client, error) {
+	auth, err := buildAuthMethods(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	defer auth.close()
+
+	sshConfig := &ssh.ClientConfig{
+		User:            config.Username,
+		Auth:            auth.methods(),
+		Timeout:         5 * time.Second,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(dialCtx, "tcp", config.Server.String())
+	if err != nil {
+		return nil, err
+	}
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
+	clientConn, chans, reqs, err := ssh.NewClientConn(conn, config.Server.String(), sshConfig)
+	close(done)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if err == nil {
+			_ = clientConn.Close()
+		} else {
+			_ = conn.Close()
+		}
+		return nil, ctxErr
+	}
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return ssh.NewClient(clientConn, chans, reqs), nil
+}
+
+// buildAuthMethods converts SSHConfig into ordered auth methods.
+func buildAuthMethods(ctx context.Context, config SSHConfig) (*authMethods, error) {
+	specs := make([]authMethodSpec, 0, 3)
+
+	if len(config.PrivateKey) > 0 {
+		method, err := buildPrivateKeyAuthMethod(config)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, authMethodSpec{
+			kind:   authMethodPrivateKey,
+			method: method,
+		})
+	}
+
+	if authSock, implicit := resolveSSHAuthSock(config); authSock != "" {
+		dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		agentClient, closer, err := dialSSHAgent(dialCtx, authSock)
+		cancel()
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			if !implicit {
+				return nil, err
+			}
+		} else {
+			specs = append(specs, authMethodSpec{
+				kind:   authMethodSSHAgent,
+				method: ssh.PublicKeysCallback(agentClient.Signers),
+				closer: closer,
+			})
+		}
+	}
+
+	if len(config.PrivateKey) == 0 && config.Passphrase != "" {
+		specs = append(specs, authMethodSpec{
+			kind:   authMethodPassword,
+			method: ssh.Password(config.Passphrase),
+		})
+	}
+
+	if len(specs) == 0 {
+		return nil, errors.New("no ssh authentication method configured")
+	}
+
+	return &authMethods{specs}, nil
+}
+
+// buildPrivateKeyAuthMethod parses the configured private key and wraps it as an SSH auth method.
+func buildPrivateKeyAuthMethod(config SSHConfig) (ssh.AuthMethod, error) {
+	if config.Passphrase != "" {
+		signer, err := ssh.ParsePrivateKeyWithPassphrase(config.PrivateKey, []byte(config.Passphrase))
+		if err != nil {
+			return nil, fmt.Errorf("parse encrypted private key: %w", err)
+		}
+		return ssh.PublicKeys(signer), nil
+	}
+
+	signer, err := ssh.ParsePrivateKey(config.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+	return ssh.PublicKeys(signer), nil
+}
+
+// resolveSSHAuthSock returns the configured agent socket or falls back to SSH_AUTH_SOCK.
+func resolveSSHAuthSock(config SSHConfig) (string, bool) {
+	if config.SSHAuthSock != "" {
+		return config.SSHAuthSock, false
+	}
+	return os.Getenv("SSH_AUTH_SOCK"), true
+}

--- a/ssh_agent_unix.go
+++ b/ssh_agent_unix.go
@@ -1,0 +1,22 @@
+//go:build unix && !android && !ios
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// dialSSHAgent connects to a Unix ssh-agent socket.
+func dialSSHAgent(ctx context.Context, authSock string) (agent.ExtendedAgent, io.Closer, error) {
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "unix", authSock)
+	if err != nil {
+		return nil, nil, fmt.Errorf("connect %s: %w", authSock, err)
+	}
+	return agent.NewClient(conn), conn, nil
+}

--- a/ssh_agent_unix_test.go
+++ b/ssh_agent_unix_test.go
@@ -1,0 +1,136 @@
+//go:build unix && !android && !ios
+
+package main
+
+import (
+	"crypto/ed25519"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+func TestBuildAuthMethodSpecsSSHAgentOnly(t *testing.T) {
+	socketPath, _, stopAgent := startTestSSHAgent(t)
+	t.Cleanup(stopAgent)
+	t.Setenv("SSH_AUTH_SOCK", socketPath)
+
+	auth := buildTestAuthMethods(t, SSHConfig{})
+	if len(auth.specs) != 1 {
+		t.Fatalf("auth method count = %d, want 1", len(auth.specs))
+	}
+	if auth.specs[0].kind != authMethodSSHAgent {
+		t.Fatalf("specs[0].kind = %q, want %q", auth.specs[0].kind, authMethodSSHAgent)
+	}
+}
+
+func TestBuildAuthMethodSpecsPrivateKeyThenAgent(t *testing.T) {
+	socketPath, _, stopAgent := startTestSSHAgent(t)
+	t.Cleanup(stopAgent)
+	t.Setenv("SSH_AUTH_SOCK", socketPath)
+
+	_, privateKeyPKCS8 := marshalTestPrivateKey(t)
+	auth := buildTestAuthMethods(t, SSHConfig{
+		PrivateKey: privateKeyPKCS8,
+	})
+
+	if len(auth.specs) != 2 {
+		t.Fatalf("auth method count = %d, want 2", len(auth.specs))
+	}
+	if auth.specs[0].kind != authMethodPrivateKey {
+		t.Fatalf("specs[0].kind = %q, want %q", auth.specs[0].kind, authMethodPrivateKey)
+	}
+	if auth.specs[1].kind != authMethodSSHAgent {
+		t.Fatalf("specs[1].kind = %q, want %q", auth.specs[1].kind, authMethodSSHAgent)
+	}
+}
+
+func TestBuildAuthMethodSpecsAgentThenPassword(t *testing.T) {
+	socketPath, _, stopAgent := startTestSSHAgent(t)
+	t.Cleanup(stopAgent)
+
+	t.Setenv("SSH_AUTH_SOCK", socketPath)
+
+	auth := buildTestAuthMethods(t, SSHConfig{
+		Passphrase: "secret",
+	})
+
+	if len(auth.specs) != 2 {
+		t.Fatalf("auth method count = %d, want 2", len(auth.specs))
+	}
+	if auth.specs[0].kind != authMethodSSHAgent {
+		t.Fatalf("specs[0].kind = %q, want %q", auth.specs[0].kind, authMethodSSHAgent)
+	}
+	if auth.specs[1].kind != authMethodPassword {
+		t.Fatalf("specs[1].kind = %q, want %q", auth.specs[1].kind, authMethodPassword)
+	}
+}
+
+func TestDialSSHAgent(t *testing.T) {
+	socketPath, privateKey, stopAgent := startTestSSHAgent(t)
+	defer stopAgent()
+
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatalf("create signer: %v", err)
+	}
+
+	client, closer, err := dialSSHAgent(t.Context(), socketPath)
+	if err != nil {
+		t.Fatalf("dialSSHAgent() error = %v", err)
+	}
+	defer closer.Close()
+
+	signers, err := client.Signers()
+	if err != nil {
+		t.Fatalf("agent Signers() error = %v", err)
+	}
+	if len(signers) != 1 {
+		t.Fatalf("agent signer count = %d, want 1", len(signers))
+	}
+	if string(signers[0].PublicKey().Marshal()) != string(signer.PublicKey().Marshal()) {
+		t.Fatal("agent signer public key mismatch")
+	}
+}
+
+func startTestSSHAgent(t *testing.T) (string, ed25519.PrivateKey, func()) {
+	t.Helper()
+
+	socketDir, err := os.MkdirTemp("", "sshtunnel-*")
+	if err != nil {
+		t.Fatalf("create agent socket dir: %v", err)
+	}
+
+	socketPath := filepath.Join(socketDir, "agent.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		_ = os.RemoveAll(socketDir)
+		t.Fatalf("listen unix socket: %v", err)
+	}
+
+	keyring := agent.NewKeyring()
+	privateKey, _ := marshalTestPrivateKey(t)
+	if err = keyring.Add(agent.AddedKey{PrivateKey: privateKey}); err != nil {
+		t.Fatalf("add key to keyring: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		_ = agent.ServeAgent(keyring, conn)
+	}()
+
+	return socketPath, privateKey, func() {
+		_ = listener.Close()
+		<-done
+		_ = os.RemoveAll(socketDir)
+	}
+}

--- a/ssh_agent_unsupported.go
+++ b/ssh_agent_unsupported.go
@@ -1,0 +1,17 @@
+//go:build !unix || android || ios
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"runtime"
+
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// dialSSHAgent reports that ssh-agent authentication is unavailable on this platform.
+func dialSSHAgent(_ context.Context, _ string) (agent.ExtendedAgent, io.Closer, error) {
+	return nil, nil, fmt.Errorf("ssh-agent authentication is not supported on %s", runtime.GOOS)
+}

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildAuthMethodSpecsPrivateKeyOnly(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	_, privateKeyPKCS8 := marshalTestPrivateKey(t)
+	auth := buildTestAuthMethods(t, SSHConfig{PrivateKey: privateKeyPKCS8})
+	if len(auth.specs) != 1 {
+		t.Fatalf("auth method count = %d, want 1", len(auth.specs))
+	}
+	if auth.specs[0].kind != authMethodPrivateKey {
+		t.Fatalf("specs[0].kind = %q, want %q", auth.specs[0].kind, authMethodPrivateKey)
+	}
+}
+
+func TestBuildAuthMethodSpecsPasswordOnly(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	auth := buildTestAuthMethods(t, SSHConfig{Passphrase: "secret"})
+	if len(auth.specs) != 1 {
+		t.Fatalf("auth method count = %d, want 1", len(auth.specs))
+	}
+	if auth.specs[0].kind != authMethodPassword {
+		t.Fatalf("specs[0].kind = %q, want %q", auth.specs[0].kind, authMethodPassword)
+	}
+}
+
+func TestBuildAuthMethodSpecsSkipsStaleEnvAgent(t *testing.T) {
+	staleSocketPath := filepath.Join(t.TempDir(), "agent.sock")
+	t.Setenv("SSH_AUTH_SOCK", staleSocketPath)
+
+	_, privateKeyPKCS8 := marshalTestPrivateKey(t)
+	auth := buildTestAuthMethods(t, SSHConfig{PrivateKey: privateKeyPKCS8})
+	if len(auth.specs) != 1 {
+		t.Fatalf("auth method count = %d, want 1", len(auth.specs))
+	}
+	if auth.specs[0].kind != authMethodPrivateKey {
+		t.Fatalf("specs[0].kind = %q, want %q", auth.specs[0].kind, authMethodPrivateKey)
+	}
+
+	auth = buildTestAuthMethods(t, SSHConfig{Passphrase: "secret"})
+	if len(auth.specs) != 1 {
+		t.Fatalf("auth method count = %d, want 1", len(auth.specs))
+	}
+	if auth.specs[0].kind != authMethodPassword {
+		t.Fatalf("specs[0].kind = %q, want %q", auth.specs[0].kind, authMethodPassword)
+	}
+
+	if _, err := buildAuthMethods(t.Context(), SSHConfig{
+		SSHAuthSock: staleSocketPath,
+		Passphrase:  "secret",
+	}); err == nil {
+		t.Fatal("buildAuthMethods() with explicit stale agent error = nil, want error")
+	}
+}
+
+func TestBuildAuthMethodSpecsReturnsCanceledContext(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "agent.sock"))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := buildAuthMethods(ctx, SSHConfig{Passphrase: "secret"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("buildAuthMethods() error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestDialSSHReturnsCanceledContext(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := DialSSH(ctx, SSHConfig{
+		Server:     NetworkAddress{Host: "127.0.0.1", Port: "1"},
+		Username:   "alice",
+		Passphrase: "secret",
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("DialSSH() error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestResolveSSHAuthSock(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/from-env.sock")
+
+	if got, implicit := resolveSSHAuthSock(SSHConfig{SSHAuthSock: "/tmp/from-config.sock"}); got != "/tmp/from-config.sock" || implicit {
+		t.Fatalf("resolveSSHAuthSock() = %q, want %q", got, "/tmp/from-config.sock")
+	}
+	if got, implicit := resolveSSHAuthSock(SSHConfig{}); got != "/tmp/from-env.sock" || !implicit {
+		t.Fatalf("resolveSSHAuthSock() = %q, want %q", got, "/tmp/from-env.sock")
+	}
+}
+
+func buildTestAuthMethods(t *testing.T, config SSHConfig) *authMethods {
+	t.Helper()
+
+	auth, err := buildAuthMethods(t.Context(), config)
+	if err != nil {
+		t.Fatalf("buildAuthMethods() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := auth.close(); err != nil {
+			t.Fatalf("auth.close() error = %v", err)
+		}
+	})
+	return auth
+}
+
+func marshalTestPrivateKey(t *testing.T) (ed25519.PrivateKey, []byte) {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 key: %v", err)
+	}
+
+	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+
+	return privateKey, pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	})
+}

--- a/tunnel.go
+++ b/tunnel.go
@@ -70,48 +70,6 @@ type TunnelSpec struct {
 	Mode   ForwardMode
 }
 
-type SSHConfig struct {
-	Server     NetworkAddress
-	Username   string
-	PrivateKey []byte
-	Passphrase string
-}
-
-func DialSSH(config SSHConfig) (*ssh.Client, error) {
-	auth, err := buildAuthMethods(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return ssh.Dial("tcp", config.Server.String(), &ssh.ClientConfig{
-		User:            config.Username,
-		Auth:            auth,
-		Timeout:         10 * time.Second,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-	})
-}
-
-func buildAuthMethods(config SSHConfig) ([]ssh.AuthMethod, error) {
-	switch {
-	case len(config.PrivateKey) > 0 && config.Passphrase != "":
-		signer, err := ssh.ParsePrivateKeyWithPassphrase(config.PrivateKey, []byte(config.Passphrase))
-		if err != nil {
-			return nil, fmt.Errorf("parse encrypted private key: %w", err)
-		}
-		return []ssh.AuthMethod{ssh.PublicKeys(signer)}, nil
-	case len(config.PrivateKey) > 0:
-		signer, err := ssh.ParsePrivateKey(config.PrivateKey)
-		if err != nil {
-			return nil, fmt.Errorf("parse private key: %w", err)
-		}
-		return []ssh.AuthMethod{ssh.PublicKeys(signer)}, nil
-	case config.Passphrase != "":
-		return []ssh.AuthMethod{ssh.Password(config.Passphrase)}, nil
-	default:
-		return nil, nil
-	}
-}
-
 // ServeTunnel accepts tunnel connections and relays each connection in its own goroutine.
 func ServeTunnel(ctx context.Context, client *ssh.Client, tunnel TunnelSpec) error {
 	listener, err := listenTunnel(client, tunnel)

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -59,7 +59,7 @@ func TestParseForwardMode(t *testing.T) {
 }
 
 func TestRelayCopiesBothDirections(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	leftA, leftB := net.Pipe()
 	rightA, rightB := net.Pipe()
 	defer leftA.Close()


### PR DESCRIPTION
## Summary
- add ssh_auth_sock and SSH_AUTH_SOCK based agent authentication support.
- refactor SSH connection and auth handling into ssh.go.

**Behavior Change**

Authentication no longer uses a single-source priority selection, the new order is to try available public key methods first (private-key, ssh_auth_sock, SSH_AUTH_SOCK) and then fall back to password auth when private-key is not configured.