### PR TITLE
Add changelog release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,16 @@ test:
 
 clean:
 	rm -rf $(BINDIR)
+
+changelog:
+	@if test -n "$$(git status --porcelain)"; then \
+		echo "working tree is not clean"; \
+		git status --short; \
+		exit 1; \
+	fi
+	@set -e; \
+	version="$$(git-cliff --bumped-version)"; \
+	echo "Generating CHANGELOG.md for $$version"; \
+	git-cliff --tag "$$version" -o CHANGELOG.md; \
+	git add CHANGELOG.md; \
+	git commit -m "chore(release): prepare for $$version"


### PR DESCRIPTION
## Summary
- add a Makefile changelog target that checks for a clean worktree
- derive the next version with git-cliff, generate CHANGELOG.md, stage it, and commit the release prep change

## Validation
- git-cliff --version
- make -n changelog
- make test