### PR TITLE
fix: fail when latest tag cannot be resolved

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -180,6 +180,9 @@ esac
 # Get latest version if none was specified
 if test -z "$version"; then
   version="$(latest_tag "$latest_url")"
+  if test -z "$version"; then
+    err "Unable to get latest tag"
+  fi
 fi
 
 if [ "$ask" = "y" ] && [ ! -t 0 ]; then


### PR DESCRIPTION
Exit early when the installer cannot resolve the latest release tag to avoid continuing with an empty version string after a failed latest-release lookup.